### PR TITLE
chore(tests): delete testing and some tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ run: build runtime setup-localstack  ## Run united devmode
 	DEV="true" AWS_PROFILE="localstack" BUCKET="united-test" KEY_ARN="alias/united-test" AUTH_URL="http://localhost:8085:/united-test" $(run)
 
 test: ## Run tests in tests/ dir
-	TF_HTTP_USERNAME=foo TF_HTTP_PASSWORD=f00f00f00 $(MAKE) -C tests
+	$(MAKE) -C tests

--- a/handlers.go
+++ b/handlers.go
@@ -45,15 +45,13 @@ func getHandler(c *gin.Context) {
 		switch apiErr.(type) {
 		case *s3types.NoSuchKey, *s3types.NotFound:
 			c.JSON(http.StatusNotFound, gin.H{"message": "Not Found"})
-
-			return
 		default:
 			//nolint:errcheck
 			c.Error(err)
 			c.JSON(http.StatusServiceUnavailable, gin.H{"message": "Could not retrieve from storage"})
-
-			return
 		}
+
+		return
 	} else if err != nil {
 		//nolint:errcheck
 		c.Error(err)
@@ -128,9 +126,11 @@ func postHandler(c *gin.Context) {
 		//nolint:errcheck
 		c.Error(err)
 		c.JSON(http.StatusServiceUnavailable, gin.H{"message": "Failed to store state"})
-	} else {
-		c.JSON(http.StatusOK, gin.H{"message": "ok"})
+
+		return
 	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "ok"})
 }
 
 // Unsure where TF calls this...
@@ -147,12 +147,8 @@ func deleteHandler(c *gin.Context) {
 		//nolint:errcheck
 		c.Error(err)
 		c.JSON(http.StatusServiceUnavailable, gin.H{"message": "Failed to delete state"})
-
-		return
 	} else {
 		c.JSON(http.StatusOK, gin.H{"message": "ok"})
-
-		return
 	}
 }
 
@@ -206,12 +202,8 @@ func lockHandler(c *gin.Context) {
 		//nolint:errcheck
 		c.Error(err)
 		c.JSON(http.StatusServiceUnavailable, gin.H{"message": "Lock failed"})
-
-		return
 	} else {
 		c.JSON(http.StatusOK, reqLock.ID)
-
-		return
 	}
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,14 @@
+.EXPORT_ALL_VARIABLES:
+TF_HTTP_USERNAME?=foo
+TF_HTTP_PASSWORD?=f00f00f00
+AWS_PROFILE?=localstack
+
 test:
 	terraform init
 	terraform apply -auto-approve
 	terraform apply -var changer=bar -auto-approve
 	terraform state pull
 	terraform destroy -auto-approve
+	terraform state pull
+
+	curl -qv -fsSL --user ${TF_HTTP_USERNAME}:${TF_HTTP_PASSWORD} -X DELETE http://localhost:8080/state/my-peoples/meNOT


### PR DESCRIPTION
Added test for DELETE action, chased my tail a bit w.r.t. env vars, permissions (we fake them in tests and they always allow), and deleteObject behavior ... this cleans things up a smidge