### PR TITLE
chore: update .renovaterc.json

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -28,6 +28,7 @@
   "separateMinorPatch": true,
   "timezone": "America/Los_Angeles",
   "minimumReleaseAge": "3 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "prCreation": "not-pending",
   "internalChecksFilter": "strict"
 }


### PR DESCRIPTION
try minimumReleaseAgeBehaviour to unstick some stuff without a timestamp